### PR TITLE
Support Gradle 8+

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -19,11 +19,10 @@ dependencies {
     implementation 'edu.illinois:nondex-instrumentation:' + version
 }
 
-pluginBundle {
+gradlePlugin {
     website = 'https://github.com/TestingResearchIllinois/NonDex'
     vcsUrl = 'https://github.com/TestingResearchIllinois/NonDex'
     description = 'NonDex plugin for Gradle'
-    tags = ['non-deterministic', 'test']
 }
 
 gradlePlugin {

--- a/plugin/src/main/java/edu/illinois/nondex/gradle/internal/CleanRun.java
+++ b/plugin/src/main/java/edu/illinois/nondex/gradle/internal/CleanRun.java
@@ -5,10 +5,14 @@ import edu.illinois.nondex.common.Level;
 import edu.illinois.nondex.common.Logger;
 import edu.illinois.nondex.common.Utils;
 import edu.illinois.nondex.gradle.tasks.AbstractNonDexTest;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestExecuter;
+import org.gradle.api.internal.tasks.testing.TestFramework;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.util.GradleVersion;
+import org.gradle.util.Path;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -57,10 +61,24 @@ public class CleanRun {
     protected JvmTestExecutionSpec createJvmExecutionSpecWithArgs(List<String> args, JvmTestExecutionSpec originalSpec) {
         JavaForkOptions option = originalSpec.getJavaForkOptions();
         option.setAllJvmArgs(args);
-        if (GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version("6.4")) >= 0) {
-            // This constructor is in Gradle 6.4+
-            return new JvmTestExecutionSpec(
-                    originalSpec.getTestFramework(),
+        GradleVersion curGradleVersion = GradleVersion.current().getBaseVersion();
+        try {
+            if (curGradleVersion.compareTo(GradleVersion.version("8.0")) >= 0) {
+                return JvmTestExecutionSpec.class.getConstructor(new Class[]{
+                    TestFramework.class,
+                    Iterable.class,
+                    Iterable.class,
+                    FileTree.class,
+                    Boolean.class,
+                    FileCollection.class,
+                    String.class,
+                    Path.class,
+                    Long.class,
+                    JavaForkOptions.class,
+                    Integer.class,
+                    Set.class,
+                    Boolean.class
+                }).newInstance(originalSpec.getTestFramework(),
                     originalSpec.getClasspath(),
                     originalSpec.getModulePath(),
                     originalSpec.getCandidateClassFiles(),
@@ -71,12 +89,48 @@ public class CleanRun {
                     originalSpec.getForkEvery(),
                     option,
                     originalSpec.getMaxParallelForks(),
-                    originalSpec.getPreviousFailedTestClasses()
-            );
-        } else {
-            // This constructor is in Gradle 4.7+
-            return new JvmTestExecutionSpec(
-                    originalSpec.getTestFramework(),
+                    originalSpec.getPreviousFailedTestClasses(),
+                    originalSpec.getTestIsModule());
+            } else if (curGradleVersion.compareTo(GradleVersion.version("6.4")) >= 0) {
+                return JvmTestExecutionSpec.class.getConstructor(new Class[]{
+                    TestFramework.class,
+                    Iterable.class,
+                    Iterable.class,
+                    FileTree.class,
+                    Boolean.class,
+                    FileCollection.class,
+                    String.class,
+                    Path.class,
+                    Long.class,
+                    JavaForkOptions.class,
+                    Integer.class,
+                    Set.class
+                }).newInstance(originalSpec.getTestFramework(),
+                    originalSpec.getClasspath(),
+                    originalSpec.getModulePath(),
+                    originalSpec.getCandidateClassFiles(),
+                    originalSpec.isScanForTestClasses(),
+                    originalSpec.getTestClassesDirs(),
+                    originalSpec.getPath(),
+                    originalSpec.getIdentityPath(),
+                    originalSpec.getForkEvery(),
+                    option,
+                    originalSpec.getMaxParallelForks(),
+                    originalSpec.getPreviousFailedTestClasses());
+            } else {
+                return JvmTestExecutionSpec.class.getConstructor(new Class[]{
+                    TestFramework.class,
+                    Iterable.class,
+                    FileTree.class,
+                    Boolean.class,
+                    FileCollection.class,
+                    String.class,
+                    Path.class,
+                    Long.class,
+                    JavaForkOptions.class,
+                    Integer.class,
+                    Set.class
+                }).newInstance(originalSpec.getTestFramework(),
                     originalSpec.getClasspath(),
                     originalSpec.getCandidateClassFiles(),
                     originalSpec.isScanForTestClasses(),
@@ -86,8 +140,10 @@ public class CleanRun {
                     originalSpec.getForkEvery(),
                     option,
                     originalSpec.getMaxParallelForks(),
-                    originalSpec.getPreviousFailedTestClasses()
-            );
+                    originalSpec.getPreviousFailedTestClasses());
+            } 
+        } catch (Exception e) {
+            return originalSpec;
         }
     }
 

--- a/plugin/src/main/java/edu/illinois/nondex/gradle/tasks/AbstractNonDexTest.java
+++ b/plugin/src/main/java/edu/illinois/nondex/gradle/tasks/AbstractNonDexTest.java
@@ -7,6 +7,9 @@ import edu.illinois.nondex.common.Mode;
 import edu.illinois.nondex.common.Utils;
 import edu.illinois.nondex.instr.Instrumenter;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.internal.provider.DefaultProperty;
+import org.gradle.api.internal.provider.PropertyHost;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskInstantiationException;
@@ -110,6 +113,13 @@ public abstract class AbstractNonDexTest extends Test {
     }
     @Input
     public String getNondexLoggingLevel() { return nondexLoggingLevel; }
+
+    @Internal
+    public Property<Boolean> getDryRun() {
+        DefaultProperty<Boolean> dryRun = new DefaultProperty<Boolean>(PropertyHost.NO_OP, Boolean.class);
+        dryRun.set(false);
+        return dryRun;
+    }
 
     @Internal
     protected Test testTask;


### PR DESCRIPTION
Support the latest Gradle Version (8.4). This PR addresses three changes:
- The constructor of Gradle's `JvmTestExecutionSpec` changed from Gradle 8.0, so use reflection to count for that.
- From Gradle 8.3+, the Gradle `Test` interface declares a new function `getDryRun()` which specifies if individual test execution shall be skipped. NonDex has its own clean execution routine so we can always set that to false.
- `pluginBundle` block is not supported anymore from Gradle 8+, and we need to switch to `gradlePlugin`, which does not have a `tags` field.